### PR TITLE
courses.yml: Set difficulty to 0

### DIFF
--- a/course.yml
+++ b/course.yml
@@ -1,7 +1,7 @@
 id: 735
 title: Intro to Python for Data Science
 programming_language: python
-difficulty_level: 1
+difficulty_level: 0
 time_needed: 4 hours
 instructors:
   - filip@datacamp.com


### PR DESCRIPTION
The 3 courses shown below "Starting your Data Science journey" are chosen by difficulty. 
If the difficulty isn't set to zero, then it isn't shown there.

(See top of page on https://www.datacamp.com/courses )