### PR TITLE
add datasets

### DIFF
--- a/course.yml
+++ b/course.yml
@@ -15,3 +15,6 @@ description: Python is a general-purpose programming language that is becoming m
   Enter DataCamp’s online Python curriculum.
 from: "python-base-prod:20"
 practice_pool_id: 107
+datasets:
+  baseball.csv: MLB (baseball)
+  fifa.csv: FIFA (soccer)


### PR DESCRIPTION
@ncarchedi, This being an intro course, students only make use of a subset of `baseball.csv` and `fifa.csv`. I'd argue that since these are interesting datasets, it's worth making them available for those who want to explore them further. However, to a student who *only* wants to explore the data in its subset form, would this be confusing?