### PR TITLE
Rename course to "Introduction to Python"

### DIFF
--- a/course.yml
+++ b/course.yml
@@ -1,5 +1,5 @@
 id: 735
-title: Intro to Python for Data Science
+title: Introduction to Python
 programming_language: python
 difficulty_level: 0
 time_needed: 4 hours


### PR DESCRIPTION
#### Problem

- This course is more of an Introduction to Python than an Introduction to Python **for** Data Science.
- We now have an [Introduction to Data Science in Python](https://www.datacamp.com/courses/introduction-to-data-science-in-python).
- Two courses with such similar titles will confuse students and is a problem from a marketing standpoint.

#### Solution

- Rename this course to ["Introduction to Python"](https://www.datacamp.com/courses/16086):

<img width="1267" alt="screenshot 2018-12-12 17 59 21" src="https://user-images.githubusercontent.com/20912644/49888758-b51c7e80-fe37-11e8-9e4a-ed02961ca104.png">

The course videos and slides will continue to say "Intro to Python for Data Science", but this is a temporary (and relatively trivial) problem that will be fixed in Q1.

Marketing and Curriculum have approved this change.

cc @mnazary @brookscrichlow @richierocks @martijnsublime 