### PR TITLE
Fix bmi SCT ch4ex4

### DIFF
--- a/chapter4.md
+++ b/chapter4.md
@@ -279,7 +279,7 @@ Ex().check_object("np_height_m", missing_msg=msg).has_equal_value(incorrect_msg 
 
 # check np_weight_kg
 Ex().check_correct(
-  check_object("np_weight_kg"),
+  check_object("np_weight_kg").has_equal_value(),
   multi(
     check_function("numpy.array", index=1).check_args(0).has_equal_ast(),
     has_code('0.453592', not_typed_msg="Make sure to multiply `np.array(weight_lb)` with `0.453592` to get the weights in kg.")


### PR DESCRIPTION
A lot of users forget the lb to kg conversion, now it was only detected when checking `bmi`.

`has_code` checks for a regex pattern by default, so `*` has to be escaped as it is a part of regex syntax.